### PR TITLE
Update link to timm model results

### DIFF
--- a/docs/model_architectures.html
+++ b/docs/model_architectures.html
@@ -38,7 +38,7 @@ nb_path: "nbs/00a_model_architectures.ipynb"
 <li>ported by myself from their original impl in a different framework (e.g. Tensorflow models)</li>
 <li>trained from scratch using the included training script</li>
 </ol>
-<p>The validation results for the pretrained weights can be found <a href="https://rwightman.github.io/pytorch-image-models/results/">here</a>.</p>
+<p>The validation results for the pretrained weights can be found <a href="https://huggingface.co/docs/timm/results/">here</a>.</p>
 
 </div>
 </div>


### PR DESCRIPTION
Just redoing the fastai course and [the link mentioned here](https://youtu.be/8SF_h3xF3cE?t=3062) is broken, timm moved their website to huggingface as in the pull request.